### PR TITLE
vmalert: bump rules evaluation concurrency

### DIFF
--- a/chart/files/alerts.yaml
+++ b/chart/files/alerts.yaml
@@ -2,6 +2,7 @@
 ##  from https://awesome-prometheus-alerts.grep.to/rules.html#host-and-hardware-1
 groups:
   - name: nodeexporter
+    concurrency: 4
     rules:
     - alert: HostOutOfMemory
       expr: node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes * 100 < 10


### PR DESCRIPTION
vmalert evaluates all rule groups concurrently
and rules within the group sequentially.
Since the default list of alerts contains only one
group, all evaluations are happening sequentially.
This might have uneven load effect on the remote read.