### PR TITLE
introduce option of nodeSelectors

### DIFF
--- a/chart/templates/nodeexporter/deployment.yaml
+++ b/chart/templates/nodeexporter/deployment.yaml
@@ -20,6 +20,10 @@ spec:
         job: nodeexporter
         {{- include "prometheus-benchmark.labels" . | nindent 8 }}
     spec:
+      {{- with $.Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: nodeexporter
         image: prom/node-exporter:v1.3.1

--- a/chart/templates/vmagent/deployment.yaml
+++ b/chart/templates/vmagent/deployment.yaml
@@ -23,6 +23,10 @@ spec:
         remote-storage-name: {{ $rsName | quote }}
         {{- include "prometheus-benchmark.labels" $ | nindent 8 }}
     spec:
+      {{- with $.Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: vmagent-config-updater
         image: "victoriametrics/vmagent-config-updater:v1.1.0"

--- a/chart/templates/vmalert/deployment.yaml
+++ b/chart/templates/vmalert/deployment.yaml
@@ -25,6 +25,10 @@ spec:
         remote-storage-name: {{ $rsName | quote }}
         {{- include "prometheus-benchmark.labels" $ | nindent 8 }}
     spec:
+      {{- with $.Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: vmalert
         image: "victoriametrics/vmalert:{{ $.Values.vmtag }}"

--- a/chart/templates/vmsingle/deployment.yaml
+++ b/chart/templates/vmsingle/deployment.yaml
@@ -20,6 +20,10 @@ spec:
         job: vmsingle
         {{- include "prometheus-benchmark.labels" . | nindent 8 }}
     spec:
+      {{- with $.Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccount: {{ include "prometheus-benchmark.fullname" . }}-vmsingle
       containers:
       - name: vmsingle

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2,6 +2,10 @@
 # which run inside the prometheus-benchmark - e.g. vmagent, vmalert, vmsingle.
 vmtag: "v1.80.0"
 
+# nodeSelector is the list of key-value pairs for selecting instances
+# where benchmark pods should be deployed.
+nodeSelector: {}
+
 # targetsCount defines the number of nodeexporter instances to scrape.
 # This option allows to configure the number of active time series to push
 # to remoteStorages.

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -4,7 +4,7 @@ vmtag: "v1.80.0"
 
 # nodeSelector is the list of key-value pairs for selecting instances
 # where benchmark pods should be deployed.
-nodeSelector: {}
+#nodeSelector: {}
 
 # targetsCount defines the number of nodeexporter instances to scrape.
 # This option allows to configure the number of active time series to push


### PR DESCRIPTION
`nodeSelector` is an option which helps to bind
benchmark pods deployment to specific instances
or instance pools. This may help to isolate
benchmark pods from datasources when run in the
same k8s cluster.