### PR TITLE
introduce option `writeReplicas`

### DIFF
--- a/chart/templates/vmagent/deployment.yaml
+++ b/chart/templates/vmagent/deployment.yaml
@@ -1,8 +1,9 @@
 {{ range $rsName, $rs := .Values.remoteStorages }}
+{{ range $replica := until ($.Values.writeReplicas | int) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "prometheus-benchmark.fullname" $ }}-vmagent-{{ $rsName }}
+  name: {{ include "prometheus-benchmark.fullname" $ }}-vmagent-{{ $rsName }}-replica-{{ $replica }}
   namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "prometheus-benchmark.labels" $ | nindent 4 }}
@@ -43,6 +44,7 @@ spec:
         - --remoteWrite.tmpDataPath=/vmagent-data
         - --remoteWrite.maxDiskUsagePerURL=2GiB
         - --remoteWrite.queues={{ $.Values.writeConcurrency }}
+        - --remoteWrite.label=replica={{ $replica }}
         {{- if $rs.writeBearerToken }}
         - --remoteWrite.bearerToken={{ $rs.writeBearerToken }}
         {{- end }}
@@ -59,4 +61,5 @@ spec:
       - name: vmagent-data
         emptyDir: {}
 ---
+{{ end }}
 {{ end }}

--- a/chart/templates/vmagent/deployment.yaml
+++ b/chart/templates/vmagent/deployment.yaml
@@ -1,5 +1,5 @@
 {{ range $rsName, $rs := .Values.remoteStorages }}
-{{ range $replica := until ($.Values.writeReplicas | int) }}
+{{ range $replica := until ($.Values.writeReplicas | default 1 | int) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -47,7 +47,7 @@ writeConcurrency: 16
 # each replica will scrape targetsCount targets and will have
 # its own extra label `replica` attached to written time series.
 # this option is useful for scaling the writers horizontally.
-writeReplicas: 1
+# writeReplicas: 1
 
 # remoteStorages contains a named list of Prometheus-compatible systems to test.
 # These systems must support data ingestion via Prometheus remote_write protocol.

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -43,6 +43,12 @@ scrapeConfigUpdateInterval: 10m
 # components and the tested remoteStorages.
 writeConcurrency: 16
 
+# replicas defines how many pods of writers to deploy.
+# each replica will scrape targetsCount targets and will have
+# its own extra label `replica` attached to written time series.
+# this option is useful for scaling the writers horizontally.
+writeReplicas: 1
+
 # remoteStorages contains a named list of Prometheus-compatible systems to test.
 # These systems must support data ingestion via Prometheus remote_write protocol.
 # These systems must also support Prometheus querying API if query performance


### PR DESCRIPTION
New option `writeReplicas` allows to deploy multiple
vmagents (writers) for each configured `remoteStorage`.
Scaling number of replicas allows to scale writers horizontally.