### PR TITLE
fix targetAddr in vmagent deployment

### DIFF
--- a/chart/templates/vmagent/deployment.yaml
+++ b/chart/templates/vmagent/deployment.yaml
@@ -34,7 +34,7 @@ spec:
         args:
         - --httpListenAddr=:8436
         - --targetsCount={{ $.Values.targetsCount }}
-        - --targetAddr=http://0.0.0.0:9102
+        - --targetAddr=0.0.0.0:9102
         - --scrapeInterval={{ $.Values.scrapeInterval }}
         - --scrapeConfigUpdatePercent={{ $.Values.scrapeConfigUpdatePercent }}
         - --scrapeConfigUpdateInterval={{ $.Values.scrapeConfigUpdateInterval }}


### PR DESCRIPTION
Fix targetAddr in vmagent deployment because vmagent is not working properly.