### PR TITLE
chart: add option to provide additional flags for vmagent

### DIFF
--- a/chart/templates/vmagent/deployment.yaml
+++ b/chart/templates/vmagent/deployment.yaml
@@ -68,6 +68,9 @@ spec:
         {{- if $rs.writeHeaders }}
         - --remoteWrite.headers={{ $rs.writeHeaders }}
         {{- end }}
+        {{- range $rs.vmagentExtraFlags }}
+        - {{ . }}
+        {{- end }}
         ports:
         - name: metrics
           containerPort: 8429

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -102,3 +102,7 @@ remoteStorages:
     # readHeaders is an optional list of headers in form `header:value`, attached to every read request.
     # multiple headers must be delimited by '^^': 'header1:value1^^header2:value2'
     readHeaders: ""
+    # vmagentExtraFlags allows to pass additional flags to vmagent.
+    vmagentExtraFlags: []
+    # - "--remoteWrite.useVMProto=true"
+


### PR DESCRIPTION
Providing additional flags might be useful for testing features without hardcoding new flags for vmagent. 
For example, recently added vmagent [VictoriaMetrics remote write protocol](https://docs.victoriametrics.com/vmagent.html#victoriametrics-remote-write-protocol) support requires setting flag to enable this for specific `remoteWrite.url` 