### PR TITLE
chart/vmsingle: add an option to disable built-in vmsingle

### DIFF
--- a/chart/templates/vmsingle/deployment.yaml
+++ b/chart/templates/vmsingle/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.deployTSDB }}
+{{- if not .Values.disableMonitoring }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/chart/templates/vmsingle/deployment.yaml
+++ b/chart/templates/vmsingle/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.deployTSDB }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -48,3 +49,4 @@ spec:
       - name: data
         persistentVolumeClaim:
           claimName: {{ include "prometheus-benchmark.fullname" . }}-vmsingle-data
+{{- end }}

--- a/chart/templates/vmsingle/pvc.yaml
+++ b/chart/templates/vmsingle/pvc.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.deployTSDB }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
@@ -11,3 +12,4 @@ spec:
   resources:
     requests:
       storage: 100G
+{{- end }}

--- a/chart/templates/vmsingle/pvc.yaml
+++ b/chart/templates/vmsingle/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.deployTSDB }}
+{{- if not .Values.disableMonitoring }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/chart/templates/vmsingle/role.yaml
+++ b/chart/templates/vmsingle/role.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.deployTSDB }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -9,3 +10,4 @@ rules:
 - apiGroups: ['']
   resources: ['pods']
   verbs: ['list','get','watch']
+{{- end }}

--- a/chart/templates/vmsingle/role.yaml
+++ b/chart/templates/vmsingle/role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.deployTSDB }}
+{{- if not .Values.disableMonitoring }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/chart/templates/vmsingle/rolebinding.yaml
+++ b/chart/templates/vmsingle/rolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.deployTSDB }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -13,3 +14,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "prometheus-benchmark.fullname" . }}-vmsingle
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/chart/templates/vmsingle/rolebinding.yaml
+++ b/chart/templates/vmsingle/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.deployTSDB }}
+{{- if not .Values.disableMonitoring }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/chart/templates/vmsingle/serviceaccount.yaml
+++ b/chart/templates/vmsingle/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.deployTSDB }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -5,3 +6,4 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "prometheus-benchmark.labels" . | nindent 4 }}
+{{- end }}

--- a/chart/templates/vmsingle/serviceaccount.yaml
+++ b/chart/templates/vmsingle/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.deployTSDB }}
+{{- if not .Values.disableMonitoring }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/chart/templates/vmsingle/vmsingle-cm.yaml
+++ b/chart/templates/vmsingle/vmsingle-cm.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.deployTSDB }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -31,3 +32,4 @@ data:
         target_label: pod
       - source_labels: [__meta_kubernetes_pod_container_name]
         target_label: container
+{{- end }}

--- a/chart/templates/vmsingle/vmsingle-cm.yaml
+++ b/chart/templates/vmsingle/vmsingle-cm.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.deployTSDB }}
+{{- if not .Values.disableMonitoring }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2,6 +2,10 @@
 # which run inside the prometheus-benchmark - e.g. vmagent, vmalert, vmsingle.
 vmtag: "v1.102.1"
 
+# Controls whether to deploy a built-in vmsingle for testing
+# Useful for testing remote systems when vmsingle is not needed
+deployTSDB: true
+
 # nodeSelector is an optional node selector for placing benchmark pods.
 nodeSelector: {}
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2,9 +2,9 @@
 # which run inside the prometheus-benchmark - e.g. vmagent, vmalert, vmsingle.
 vmtag: "v1.102.1"
 
-# Controls whether to deploy a built-in vmsingle for testing
-# Useful for testing remote systems when vmsingle is not needed
-deployTSDB: true
+# Controls whether to deploy a built-in vmsingle for monitoring
+# Useful if there is monitoring already in place and built-in vmsingle is not needed.
+disableMonitoring: false
 
 # nodeSelector is an optional node selector for placing benchmark pods.
 nodeSelector: {}


### PR DESCRIPTION
This is useful for cases when remote system is being tested, so vmsingle is not needed.
Change is backwards compatible as TSDB is still deployed by default.