### PR TITLE
chart/{vmagent,vmalert}: add an ability to provide extra env variables

### DIFF
--- a/chart/templates/vmagent/deployment.yaml
+++ b/chart/templates/vmagent/deployment.yaml
@@ -71,6 +71,10 @@ spec:
         {{- range $rs.vmagentExtraFlags }}
         - {{ . }}
         {{- end }}
+        {{- with $rs.vmagentExtraEnvs }}
+        env:
+        {{- toYaml . | nindent 10 }}
+        {{- end }}
         ports:
         - name: metrics
           containerPort: 8429

--- a/chart/templates/vmalert/deployment.yaml
+++ b/chart/templates/vmalert/deployment.yaml
@@ -32,6 +32,10 @@ spec:
       containers:
       - name: vmalert
         image: "victoriametrics/vmalert:{{ $.Values.vmtag }}"
+        {{- with $rs.vmalertExtraEnvs }}
+        env:
+        {{- toYaml . | nindent 10 }}
+        {{- end }}
         args:
         - --httpListenAddr=:8880
         - --notifier.url=http://127.0.0.1:9093
@@ -45,6 +49,9 @@ spec:
         - --remoteRead.headers={{ $rs.readHeaders }}
         - --remoteWrite.headers={{ $rs.readHeaders }}
         - --datasource.headers={{ $rs.readHeaders }}
+        {{- end }}
+        {{- range $rs.vmalertExtraFlags }}
+        - {{ . }}
         {{- end }}
         ports:
         - name: metrics

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -106,3 +106,27 @@ remoteStorages:
     vmagentExtraFlags: []
     # - "--remoteWrite.useVMProto=true"
 
+    vmalertExtraFlags: []
+    # - "--envflag.enable=true"
+
+    # Extra env variables for vmagent container.
+    # See: https://docs.victoriametrics.com/#environment-variables
+    vmagentExtraEnvs: [ ]
+    # - name: "VM_EXTRA_ENV"
+    #   value: "value"
+    # - name: "VM_LICENSE"
+    #   valueFrom:
+    #     secretKeyRef:
+    #       name: "vm-license"
+    #       key: "license-key"
+
+    # Extra env variables for vmagent container.
+    # See: https://docs.victoriametrics.com/#environment-variables
+    vmalertExtraEnvs: [ ]
+    # - name: "VM_EXTRA_ENV"
+    #   value: "value"
+    # - name: "VM_LICENSE"
+    #   valueFrom:
+    #     secretKeyRef:
+    #       name: "vm-license"
+    #       key: "license-key"


### PR DESCRIPTION
Added an ability to provide additional env vars and command-line flags for vmalert and vmagent.
This is useful when flag values are supposed to be passed "secretly", for example by using `envflag` and secrets to env vars propagation in k8s.