### PR TITLE
chart/write: extend write path configuration

### DIFF
--- a/chart/templates/vmagent/deployment.yaml
+++ b/chart/templates/vmagent/deployment.yaml
@@ -1,4 +1,6 @@
 {{ range $rsName, $rs := .Values.remoteStorages }}
+{{ if $rs.writeURL }}
+{{ $writeURLs := $rs.writeURL | splitList "," }}
 {{ range $replica := until ($.Values.writeReplicas | default 1 | int) }}
 apiVersion: apps/v1
 kind: Deployment
@@ -51,8 +53,10 @@ spec:
         - --remoteWrite.showURL
         - --promscrape.config=http://0.0.0.0:8436/api/v1/config
         - --promscrape.configCheckInterval={{ $.Values.scrapeConfigUpdateInterval }}
+        {{- range $url := $writeURLs }}
         {{- range $urlReplica := until ($rs.writeURLReplicas | default 1 | int) }}
-        - --remoteWrite.url={{ $rs.writeURL }}?extra_label=url_replica={{ $urlReplica }}
+        - --remoteWrite.url={{ $url }}?extra_label=url_replica={{ $urlReplica }}
+        {{- end }}
         {{- end }}
         - --remoteWrite.tmpDataPath=/vmagent-data
         - --remoteWrite.maxDiskUsagePerURL=100MiB
@@ -151,5 +155,6 @@ spec:
       - name: nginx-empty
         emptyDir: {}
 ---
+{{ end }}
 {{ end }}
 {{ end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -81,7 +81,10 @@ remoteStorages:
     # For example, the following urls may be used for testing VictoriaMetrics:
     # - http://<victoriametrics-addr>:8428/api/v1/write for single-node VictoriaMetrics
     # - http://<vminsert-addr>:8480/insert/0/prometheus/api/v1/write for cluster VictoriaMetrics
-    writeURL: "http://victoria-metrics-victoria-metrics-cluster-vminsert.default.svc.cluster.local:8480/insert/0/prometheus/api/v1/write"
+    # It is possible to send data to multiple remote endpoints by specifying
+    # multiple writeURL entries split by ",", e.g.:
+    # writeURL: "http://<vminsert-cluster-1>:8480/insert/0/prometheus/api/v1/write,http://<vminsert-cluster-2>:8480/insert/0/prometheus/api/v1/write"
+    writeURL: ""
     # writeURLReplicas is an optional number of writeURL replicas to send data to.
     # A unique `url_replica` label is added to every writeURL replica via `extra_label` query arg
     # in order to generate unique time series.


### PR DESCRIPTION
- allow using multiple remote write URLs - this allows to replicate exactly the same data between multiple installations under test. Previously, it would require running separate node exporter+vmagent pods which could land on different nodes in k8s, so node-exporter will produce different number of series (based on number of network interfaces, disks, CPU cores etc).

- allow disabling write path for certain remote storages - this is useful when setting up a single remote write path to replicate exactly the same data and setting up read path to simulate read path for multiple test targets.

- set empty value for writeURL by default - this is consistent with readURL configuration nad makes it easier to override and spot a missing config if needed.

FYI: @rtm0 