### PR TITLE
chart: update vmagent-config-updater to the latest version

### DIFF
--- a/chart/templates/vmagent/deployment.yaml
+++ b/chart/templates/vmagent/deployment.yaml
@@ -39,7 +39,7 @@ spec:
       {{- end }}
       containers:
       - name: vmagent-config-updater
-        image: "victoriametrics/vmagent-config-updater:v1.1.0"
+        image: "victoriametrics/vmagent-config-updater:v2.1.0"
         args:
         - --httpListenAddr=:8436
         - --targetsCount={{ $.Values.writes.prometheus.targetsCount }}


### PR DESCRIPTION
The latest version is the same as the previous one, except that it is a multiarch one (see https://github.com/VictoriaMetrics/prometheus-benchmark/pull/34).